### PR TITLE
fix(client): destinations without address families

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -304,6 +304,11 @@ func (c *client) Destinations(svc Service) ([]DestinationExtended, error) {
 	dests := make([]DestinationExtended, 0, len(msgs))
 	for _, msg := range msgs {
 		var dest DestinationExtended
+		// In Linux kernels before 3.18, the address family of a destination
+		// could not differ from the service. Pass down the service's address
+		// family, which will be overridden by the kernel, if available.
+		dest.Family = svc.Family
+
 		ad, err := netlink.NewAttributeDecoder(msg.Data)
 		if err != nil {
 			return nil, err

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -582,7 +582,9 @@ func TestDestinations_Unpack(t *testing.T) {
 		client := testClient(t, genltest.CheckRequest(familyID, cipvs.CmdGetDest, netlink.Request|netlink.Dump, fn))
 		defer client.Close()
 
-		result, err := client.Destinations(Service{})
+		result, err := client.Destinations(Service{
+			Family: INET,
+		})
 		assert.NilError(t, err)
 
 		dests := make([]Destination, 0, len(result))
@@ -621,6 +623,45 @@ func TestDestinations_Unpack(t *testing.T) {
 								{
 									Type: cipvs.DestAttrAddrFamily,
 									Data: []byte{0x02, 0x00},
+								},
+							}),
+						},
+					}),
+				},
+			},
+			expected: []Destination{
+				{
+					Address:   netip.MustParseAddr("127.0.1.1"),
+					FwdMethod: DirectRoute,
+					Weight:    1,
+					Port:      80,
+					Family:    INET,
+				},
+			},
+		},
+		{
+			name: "direct no address family",
+			msgs: []genetlink.Message{
+				{
+					Data: nltest.MustMarshalAttributes([]netlink.Attribute{
+						{
+							Type: cipvs.CmdAttrDest,
+							Data: nltest.MustMarshalAttributes([]netlink.Attribute{
+								{
+									Type: cipvs.DestAttrAddr,
+									Data: []byte{0x7F, 0, 0x01, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+								},
+								{
+									Type: cipvs.DestAttrFwdMethod,
+									Data: []byte{0x03, 0x00, 0x00, 0x00},
+								},
+								{
+									Type: cipvs.DestAttrWeight,
+									Data: []byte{0x01, 0x00, 0x00, 0x00},
+								},
+								{
+									Type: cipvs.DestAttrPort,
+									Data: []byte{0x00, 0x50},
 								},
 							}),
 						},


### PR DESCRIPTION
In some legacy kernels IPVS did not support destinations with differing address families from their services. This was changed to allow tunneling IPv4 traffic over an IPv6 network, and in the process destinations gained an address family field.

If this package was used on kernels predating this change, no address family would have been found, and IP address parsing was done in IPv6 mode. This changeset now defaults to the service's address family if not set by the destination.

Bug: #13
Reference: https://www.spinics.net/lists/lvs-devel/msg03723.html