### PR TITLE
fix(netmask): text marshaler with multibyte prefix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/xlab/c-for-go v0.0.0-20230906092656-a1822f0a09c1
 	golang.org/x/tools v0.14.0
 	gotest.tools/v3 v3.4.0
+	pgregory.net/rapid v1.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -73,3 +73,5 @@ modernc.org/strutil v1.1.3 h1:fNMm+oJklMGYfU9Ylcywl0CO5O6nTfaowNsh2wpPjzY=
 modernc.org/strutil v1.1.3/go.mod h1:MEHNA7PdEnEwLvspRMtWTNnp2nnyvMfkimT1NKNAGbw=
 modernc.org/token v1.0.1 h1:A3qvTqOwexpfZZeyI0FeGPDlSWX5pjZu9hF4lU+EKWg=
 modernc.org/token v1.0.1/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
+pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
+pgregory.net/rapid v1.1.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=

--- a/netmask/mask.go
+++ b/netmask/mask.go
@@ -254,8 +254,12 @@ func (mask *Mask) UnmarshalText(text []byte) error {
 	case n == 0:
 		*mask = Mask{}
 		return nil
-	case n == 1:
-		*mask = MaskFrom(int(text[0]), 128)
+	case n >= 1 && n <= 3:
+		u, err := strconv.ParseUint(string(text[:]), 10, 64)
+		if err != nil {
+			return err
+		}
+		*mask = MaskFrom(int(u), 128)
 		return nil
 	case n >= len("1.1.1.1") && n <= len("255.255.255.255"):
 		sub := strings.SplitN(string(text), ".", 4)

--- a/netmask/testdata/rapid/TestNetmask_TextMarshaller/TestNetmask_TextMarshaller-20240706211239-1271900.fail
+++ b/netmask/testdata/rapid/TestNetmask_TextMarshaller/TestNetmask_TextMarshaller-20240706211239-1271900.fail
@@ -1,0 +1,9 @@
+# 2024/07/06 21:12:39.000571 [TestNetmask_TextMarshaller] [rapid] draw mask: netmask.Mask{mask:0xa, z:2}
+# 2024/07/06 21:12:39.000578 [TestNetmask_TextMarshaller] assertion failed: error is not nil: unexpected slice size
+# 
+v0.4.8#5215856823522468385
+0x38e38e38e38e4
+0x2
+0x0
+0x9867f1f40f739
+0xa


### PR DESCRIPTION
For the IPv6 family the Mask type stores a prefix, rather than a full 128-bit mask. To implement the TextMarshaller interface for these prefixes, Mask marshals the number of one-bits in the prefix to a string.

However, the unmarshal function expected IPv6 family prefixes to only ever be 1 byte long. This holds true for the BinaryMarshaller implementation, but in text prefixes larger than 9 would be represented by multiple bytes, one for each numeric digit.

This implementation adjusts the unmarshal implementation to accept lengths up to 3 bytes for IPv6.

Fixes: bc6bb04 ("feat: value type for IP netmasks")