### PR TITLE
feat(client): add support for getting and setting the IPVS connection timeout values

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,6 +16,9 @@ import (
 type Client interface {
 	Info() (Info, error)
 
+	Config() (Config, error)
+	SetConfig(Config) error
+
 	Services() ([]ServiceExtended, error)
 	Service(Service) (ServiceExtended, error)
 	CreateService(Service) error
@@ -97,6 +100,14 @@ type Stats struct {
 type Info struct {
 	Version             [3]int
 	ConnectionTableSize uint32
+}
+
+// Config represents the timeout values (in seconds) for TCP sessions,
+// TCP sessions after receiving a FIN packet, and UDP packets.
+type Config struct {
+	TCPTimeout    uint32
+	TCPFinTimeout uint32
+	UDPTimeout    uint32
 }
 
 // New returns an instance of Client.

--- a/client_others.go
+++ b/client_others.go
@@ -23,6 +23,14 @@ func (c *client) Info() (Info, error) {
 	return Info{}, errUnimplemented
 }
 
+func (c *client) Config() (Config, error) {
+	return Config{}, errUnimplemented
+}
+
+func (c *client) SetConfig(config Config) error {
+	return errUnimplemented
+}
+
 func (c *client) Services() ([]ServiceExtended, error) {
 	return nil, errUnimplemented
 }


### PR DESCRIPTION
Hey Cloudflare team , would love to hear you feedback on this addition to the package. We were missing a method to programatically replace a call similar to `ipvsadm --set X Y Z` . I was able to setup a test for the `ipvsadm --list --timeout` / `Config()` method , but was struggling with the approach of testing the `--set` `SetConfig()` approach. Would love to hear your thoughts on this one 