### PR TITLE
fix(netmask): prefix length integer overflow

### DIFF
--- a/netmask/mask.go
+++ b/netmask/mask.go
@@ -287,7 +287,7 @@ func (mask *Mask) UnmarshalText(text []byte) error {
 		*mask = Mask{}
 		return nil
 	case n >= 1 && n <= 3:
-		u, err := strconv.ParseUint(string(text[:]), 10, 64)
+		u, err := strconv.ParseUint(string(text[:]), 10, 8)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The netmask UnmarshalText function parsed the IPv6 prefix length into a uint64 then converted to an int, which can be a smaller size (eg, on 32-bit platforms). As the prefix length can't exceed 128, instead parse as a uint8.